### PR TITLE
Fix chktex string in prompt

### DIFF
--- a/ai_scientist/perform_writeup.py
+++ b/ai_scientist/perform_writeup.py
@@ -78,7 +78,7 @@ If duplicated, identify the best location for the section header and remove any 
         # Filter trivial bugs in chktex
         check_output = os.popen(f"chktex {writeup_file} -q -n2 -n24 -n13 -n1").read()
         if check_output:
-            prompt = f"""Please fix the following LaTeX errors in `template.tex` guided by the output of `chktek`:
+            prompt = f"""Please fix the following LaTeX errors in `template.tex` guided by the output of `chktex`:
 {check_output}.
 
 Make the minimal fix required and do not remove or change any packages.


### PR DESCRIPTION
## Summary
- fix spelling of `chktex` inside perform_writeup prompt

## Testing
- `python3 -m flake8` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68540433dd348326abd4c4674126fcde